### PR TITLE
Fix crash when using OpenGL ES 3.0+ functions on Android

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -45,7 +45,7 @@ FPLBASE_COMMON_SRC_FILES := \
   src/type_conversions_gl.cpp \
   src/utilities.cpp \
   src/version.cpp \
-  $(NDK_ROOT)/sources/android/ndk_helper/gl3stub.c
+  src/gl3stub_android.c
 
 FPLBASE_EXPORT_COMMON_CPPFLAGS := -std=c++11 \
                                   -DFPLBASE_OPENGL

--- a/src/gl3stub_android.c
+++ b/src/gl3stub_android.c
@@ -1,0 +1,19 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __ANDROID__
+#if __ANDROID_API__ < 18
+#include "gl3stub.c"
+#endif  // __ANDROID_API__ < 18
+#endif  // __ANDROID__


### PR DESCRIPTION
Refs #7 