### PR TITLE
Fix warning on signed-unsigned comparison

### DIFF
--- a/src/mesh_common.cpp
+++ b/src/mesh_common.cpp
@@ -98,7 +98,7 @@ bool Mesh::IsValidFormat(const Attribute *attributes) {
   bool seen[kMaxAttributes] = {false};
   int count = 0;
   for (;; attributes++) {
-    int index = 0;
+    size_t index = 0;
     // clang-format off
     switch (*attributes) {
       case kPosition3f:     index = kAttributePosition;      break;


### PR DESCRIPTION
The `int` type triggers a compilation error when using `-Werror`.

```
fplbase/src/mesh_common.cpp:118:18: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     assert(index < FPL_ARRAYSIZE(seen));
```