### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/mesh_common.cpp
+++ b/src/mesh_common.cpp
@@ -117,7 +117,7 @@ bool Mesh::IsValidFormat(const Attribute *attributes) {
     // clang-format on
     assert(index < FPL_ARRAYSIZE(seen));
     if (seen[index] || count == kMaxAttributes) {
-      return false;
+      break;
     }
     seen[index] = true;
     ++count;

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -42,6 +42,11 @@ void DrawElement(int32_t count, int32_t instances, uint32_t index_type,
     GL_CALL(glDrawElements(gl_primitive, count, index_type, kNullIndices));
   } else {
     assert(support_instancing);
+
+    // Reference support_instancing to avoid compilation warning
+    // in release mode.
+    (void)support_instancing;
+
     GL_CALL(glDrawElementsInstanced(gl_primitive, count, index_type,
                                     kNullIndices, instances));
   }
@@ -124,7 +129,7 @@ static std::vector<std::string> GetExtensions() {
   if (glGetError() == GL_NO_ERROR) {
     extensions.reserve(num_extensions);
     for (int i = 0; i < num_extensions; ++i) {
-      auto res = glGetStringi(GL_EXTENSIONS, i);
+      res = glGetStringi(GL_EXTENSIONS, i);
       if (res != nullptr) {
         extensions.push_back(reinterpret_cast<const char *>(res));
       }


### PR DESCRIPTION
Fix compilation warnings when building using Visual C++ in Win32 architecture.

This commit fixes 3 compilation warning I ran into:

One for unreachable code in ``Mesh::IsValidFormat``, which is placed after the search loop. The Visual C++ compiler detects it as unreachable code since there was no way to continue after the search loop. (I assume the ``return false;`` statement there is to avoid warnings or errors about not all control paths returning values in compilers that do not detect unreachable code.)

Another compilation warning occurs in the local helper function ``DrawElement`` in ``renderer_gl.cpp`` as in release mode, the ``support_instancing`` parameter would be unused since the previous ``assert`` macro which does reference the variable is not evaluated in release mode.

The third warning is a local variable definition with the same name (``res``) in the same scope in ``GetExtensions`` function (also in ``renderer_gll.cpp``).